### PR TITLE
Levanta la versión a Java 11 y a Spring Boot 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
     <groupId>io.github.jokoframework</groupId>
     <artifactId>joko-backend-starter-kit</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.20.RELEASE</version>
+        <version>2.1.5.RELEASE</version>
     </parent>
 
     <properties>
@@ -20,12 +20,12 @@
         <dist.project.name>Starter Kit</dist.project.name>
         <dist.project.description>Starter Kit</dist.project.description>
         <start-class>io.github.jokoframework.myproject.Application</start-class>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <joko-security.version>1.0.1</joko-security.version>
-        <joko-utils.version>0.5.2</joko-utils.version>
+        <joko-security.version>1.1.0</joko-security.version>
+        <joko-utils.version>0.6.0</joko-utils.version>
         <commons-lang3.version>3.1</commons-lang3.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <orika-core.version>1.4.6</orika-core.version>

--- a/src/main/java/io/github/jokoframework/myproject/Application.java
+++ b/src/main/java/io/github/jokoframework/myproject/Application.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/io/github/jokoframework/myproject/basic/repositories/PersonRepository.java
+++ b/src/main/java/io/github/jokoframework/myproject/basic/repositories/PersonRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface PersonRepository extends JpaRepository<PersonEntity, Long>, JpaSpecificationExecutor<PersonEntity> {
-    PersonEntity findById(Long personId);
+    PersonEntity getOne(Long personId);
     
     PersonEntity findByIdentificationNumber(String identificationNumber);
 }

--- a/src/main/java/io/github/jokoframework/myproject/profile/service/impl/UserServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/myproject/profile/service/impl/UserServiceImpl.java
@@ -45,7 +45,7 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public UserEntity getByIdAndFailIfNotExist(Long userId, Boolean failIfNotExist) throws UserException {
-		UserEntity user = repository.findOne(userId);
+        UserEntity user = repository.getOne(userId);
 		if(user==null && failIfNotExist){
 			throw UserException.notFound(userId);
 		}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,10 @@ spring.datasource.username=postgres
 spring.datasource.password=123456
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# Requisitos para Java 11 y Spring Boot 2
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+
 spring.jackson.serialization.write-dates-as-timestamps:false
 server.context-path=/
 

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -9,3 +9,7 @@ spring.datasource.url=jdbc\:postgresql\://localhost\:5432/starter_kit
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.username=postgres
 spring.datasource.password=postgres
+
+# Requisitos para Java 11 y Spring Boot 2
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true


### PR DESCRIPTION
- Aplica cambios varios requeridos con el cambio de versión

- Utiliza las nuevas versiones de joko-security y joko-utils que utilizan Java 11 y Spring Boot 2

- Agrega requisitos para Java 11 y Spring Boot 2 a los ejemplos del archivo "application.properties"