### PR TITLE
Security fix 2022 12

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -369,6 +369,8 @@
    file name: spring-boot-starter-security-2.6.10.jar
    ]]></notes>
         <cve>CVE-2022-22978</cve>
+	<!-- temporary 2022-12-07 - afeltes - https://nvd.nist.gov/vuln/detail/CVE-2022-1471 --> 
+        <cve>CVE-2022-1471</cve>
     </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <commons-text.version>1.10.0</commons-text.version>
 
         <dom4j.version>2.1.3</dom4j.version>
-        <jackson-databind.version>2.12.6.1</jackson-databind.version>
+        <jackson-databind.version>2.12.7.1</jackson-databind.version>
         <h2.version>2.1.214</h2.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <slf4j-simple.version>1.7.36</slf4j-simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
     <groupId>io.github.jokoframework</groupId>
     <artifactId>joko-backend-starter-kit</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.10</version>
+        <version>2.7.6</version>
     </parent>
 
     <properties>
@@ -24,16 +24,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <joko-security.version>1.2.12</joko-security.version>
-        <joko-utils.version>0.6.6</joko-utils.version>
+        <joko-security.version>1.2.14</joko-security.version>
+        <joko-utils.version>0.6.7</joko-utils.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <orika-core.version>1.5.4</orika-core.version>
 
-        <dependency-check.version>7.1.0</dependency-check.version>
+        <dependency-check.version>7.4.0</dependency-check.version>
         <jjwt.version>0.9.1</jjwt.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <commons-text.version>1.9</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
 
         <dom4j.version>2.1.3</dom4j.version>
         <jackson-databind.version>2.12.6.1</jackson-databind.version>
@@ -202,6 +202,25 @@
         </dependency>
 
     </dependencies>
+
+
+    <dependencyManagement>
+        <dependencies>
+		<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+		<dependency>
+		    <groupId>org.postgresql</groupId>
+		    <artifactId>postgresql</artifactId>
+		    <version>42.5.1</version>
+		</dependency>
+		<!-- security fix pending https://nvd.nist.gov/vuln/detail/CVE-2022-1471 --> 
+            	<dependency>
+               		<groupId>org.yaml</groupId>
+	                <artifactId>snakeyaml</artifactId>
+	                <version>1.33</version>
+	        </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 
     <build>
         <plugins>


### PR DESCRIPTION
Remove critical security issues inherited from dependencies.
There are still no fix for

    https://nvd.nist.gov/vuln/detail/CVE-2022-1471
    [CVE-2022-41854](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41854)

https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.33