### PR TITLE
Permite montar el entorno con Docker Compose y PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ COPY pom.xml pom.xml
 COPY src src
 RUN apt-get update && apt-get install dos2unix && dos2unix /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/entrypoint.sh
 
-#Start application
+# Configura variables de entorno
+RUN mkdir /opt/starter-kit && mkdir /opt/starter-kit/dev
+COPY src/main/resources/application.properties.example /opt/starter-kit/dev/application.properties
+
+# Inicia la aplicación
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,59 @@
 version: "3.5"
 services:
   spring-boot:
+    container_name: joko-backend
     image: spring-boot
     build:
       context: .
+    network_mode: "host"
+    depends_on:
+      liquibase:
+        condition: service_completed_successfully
     ports:
       - "8080:8080"
       - "5005:5005"
     volumes:
       - ${MAVEN_SETTINGS_FOLDER}:/root/.m2
+    environment:
+      - 'SPRING_CONFIG_LOCATION=/opt/starter-kit/dev/application.properties'
+      # Configuración de la base de datos
+      - 'SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:6432/joko_db'
+      - 'SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver'
+      - SPRING_DATASOURCE_USERNAME=joko_user
+      - SPRING_DATASOURCE_PASSWORD=joko_password
+      # Requisitos para Java 11 y Spring Boot 2
+      - SPRING_JPA_PROPERTIES_HIBERNATE_JDBC_LOB_NON_CONTEXTUAL_CREATION=true
+      - SPRING_JPA_PROPERTIES_HIBERNATE_ENABLE_LAZY_LOAD_NO_TRANS=true
+      # Modo para encontrar el secreto (BD o FILE)
+      - 'joko.secret.mode=BD'
+      # Archivo que contiene el secreto para firmar los tokens
+      - 'joko.secret.file=/opt/joko/secret.key'
+      # En produccion usamos ruta relativa a donde
+      # se va a instalar el servicio de windows
+      #- 'joko.authentication.enable=true'
+  postgres:
+    container_name: joko-database
+    image: postgres
+    healthcheck:
+      test: pg_isready -U joko_user -d joko_db
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 6432:5432
+    volumes:
+      - ./init_db.sh:/docker-entrypoint-initdb.d/init_db.sh
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=password
+  liquibase:
+    container_name: joko-migrations
+    image: liquibase/liquibase
+    network_mode: "host"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./src/main/resources/db/liquibase/:/liquibase/changelog
+      - ./src/main/resources/db/sql/:/sql
+    command: --url="jdbc:postgresql://localhost:6432/joko_db" --changeLogFile=db-changelog.xml --username=joko_user --password=joko_password update

--- a/init_db.sh
+++ b/init_db.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+set -x
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE joko_db;
+    CREATE USER joko_user WITH PASSWORD 'joko_password';
+    ALTER USER joko_user WITH CREATEDB;
+    ALTER DATABASE joko_db OWNER TO joko_user;
+    GRANT ALL PRIVILEGES ON DATABASE joko_db TO joko_user;
+EOSQL

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <joko-security.version>1.2.14</joko-security.version>
+        <joko-security.version>1.2.13</joko-security.version>
         <joko-utils.version>0.6.7</joko-utils.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
@@ -199,6 +199,13 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.6.0</version>
         </dependency>
 
     </dependencies>

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -44,7 +44,7 @@ PROP_FILE=${PROFILE_DIR}/application.properties
 URL=$(grep ^spring.datasource.url $PROP_FILE | cut -d '=' -f 2)
 HOSTPORT=$(echo $URL |  cut -d '/' -f 3)
 PORT=$(echo $HOSTPORT | cut -d ':' -f 2)
-HOST=$(echo $HOSTPORT | cut -d '\' -f 1)
+HOST=$(echo $HOSTPORT | cut -d ':' -f 1)
 DB=$(echo $URL | cut -d '/' -f 4)
 
 USERNAME=$(grep ^spring.datasource.username $PROP_FILE | cut -d '=' -f 2)

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -5,11 +5,19 @@
 #
 # Tipicamente solo se configura la BD
 #
-spring.datasource.url=jdbc\:postgresql\://localhost\:5432/starter_kit
+spring.datasource.url=jdbc\:postgresql\://localhost\:6432/joko_db
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.username=joko_user
+spring.datasource.password=joko_password
 
 # Requisitos para Java 11 y Spring Boot 2
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+
+
+# Modo para encontrar el secreto (BD o FILE)
+joko.secret.mode=BD
+# Archivo que contiene el secreto para firmar los tokens
+joko.secret.file=/opt/joko/secret.key
+# En produccion usamos ruta relativa a donde
+# se va a instalar el servicio de windows

--- a/src/main/resources/db/liquibase/db-changelog-joko-security-v1.0.1.xml
+++ b/src/main/resources/db/liquibase/db-changelog-joko-security-v1.0.1.xml
@@ -7,19 +7,19 @@
 	</changeSet>
 
 	<changeSet author="danicricco" id="1518643732286-1">
-		<createSequence sequenceName="joko_security.audit_session_id_seq"/>
+		<createSequence sequenceName="audit_session_id_seq" schemaName="joko_security"/>
 	</changeSet>
 	<changeSet author="danicricco" id="1518643732286-2">
-		<createSequence sequenceName="joko_security.consumer_api_id_seq"/>
+		<createSequence sequenceName="consumer_api_id_seq" schemaName="joko_security"/>
 	</changeSet>
 	<changeSet author="danicricco" id="1518643732286-3">
-		<createSequence sequenceName="joko_security.principal_session_id_seq"/>
+		<createSequence sequenceName="principal_session_id_seq" schemaName="joko_security"/>
 	</changeSet>
 	<changeSet author="danicricco" id="1518643732286-4">
-		<createSequence sequenceName="joko_security.security_profile_id_seq"/>
+		<createSequence sequenceName="security_profile_id_seq" schemaName="joko_security"/>
 	</changeSet>
 	<changeSet author="danicricco" id="1518643732286-100">
-		<createSequence sequenceName="joko_security.id_seq"/>
+		<createSequence sequenceName="id_seq" schemaName="joko_security"/>
 	</changeSet>
 
 

--- a/src/main/resources/db/liquibase/db-changelog.xml
+++ b/src/main/resources/db/liquibase/db-changelog.xml
@@ -14,4 +14,7 @@
     <!-- Colocar aquí todos los cambios que se hagan desde el setup del proyecto -->
     <!-- -->
     <include file="db-changelog-evolution.xml" relativeToChangelogFile="true"/>
+
+    <!-- Ejecuta los scripts para poblar la base de datos -->
+    <includeAll path="../sql/" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
El montaje usa tres contenedores. Primero, se inicia la base de datos con un contenedor PostgreSQL. Para evitar que ocurra una condición de carrera, se define un health check que ejecuta el comando pg_isready cada tantos segundos. Recién cuando este se ejecuta y detecta que la base de datos terminó de arrancar, se invoca un contenedor Liquibase el cual actualiza las tablas y ejecuta los scripts que insertan datos iniciales. Una vez que este finaliza, se arranca un contenedor Spring Boot para el Joko Backend.